### PR TITLE
Update to properly handle MultiCompiler instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ module.exports = function(config) {
 			// each file acts as entry point for the webpack configuration
 		],
 
+		frameworks: ['webpack'],
+
 		preprocessors: {
 			// add webpack as preprocessor
 			'test/*_test.js': ['webpack'],

--- a/example/karma.conf.js
+++ b/example/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
 
 
 	// frameworks to use
-	frameworks: ['mocha'],
+	frameworks: ['webpack', 'mocha'],
 
 
 	// list of files / patterns to load in the browser

--- a/example/karma.conf.js
+++ b/example/karma.conf.js
@@ -23,14 +23,14 @@ module.exports = function(config) {
 	},
 	
 	
-	webpack: {
+	webpack: [{
 		watch: true,
 		module: {
 			loaders: [
 				{ test: /\.coffee$/, loader: "coffee-loader" }
 			]
 		}
-	},
+	}],
 
 
 	webpackServer: {

--- a/index.js
+++ b/index.js
@@ -160,6 +160,10 @@ function createPreprocesor(/* config.basePath */basePath, webpackPlugin, logger,
 
 		// read blocks until bundle is done
 		webpackPlugin.readFile(path.relative(basePath, file.path), function(err, content) {
+			if (err) {
+				throw err;
+			}
+
 			webpackPlugin.karmaWaitsForPreprocessing = false;
 			// Hack: file.sha
 			//

--- a/index.js
+++ b/index.js
@@ -32,39 +32,40 @@ function Plugin(/* config.port */karmaPort, /* config.hostname */hostname, /* co
 		compiler.plugin("compilation", function(compilation, params) {
 			compilation.dependencyFactories.set(SingleEntryDependency, params.normalModuleFactory);
 		});
-		compiler.plugin("done", function(stats) {
-			var compilation = stats.compilation;
-			stats = stats.toJson();
-
-			if(!this.waiting || this.waiting.length === 0) {
-				// If file required in tests is changed, webpack compilation is done silently for karma.
-				// Fix this by emulating test file change.
-				this.notifyKarmaAboutChanges(stats);
-			}
-
-			var complete = true;
-			if (stats.children && stats.children.length) {
-				complete = stats.children.every(function(stats) {
-					return stats.assets.length > 0;
-				});
-			}
-			if (stats.assets) {
-				complete = complete && stats.assets.length > 0;
-			}
-
-			if(this.waiting && complete) {
-				var w = this.waiting;
-				this.waiting = null;
-				w.forEach(function(cb) {
-					cb();
-				});
-			}
-		}.bind(this));
-		compiler.plugin("invalid", function() {
-			if(!this.waiting) this.waiting = [];
-		}.bind(this));
 		compiler.plugin("make", this.make.bind(this));
 	}, this);
+
+	compiler.plugin("done", function(stats) {
+		var compilation = stats.compilation;
+		stats = stats.toJson();
+
+		if(!this.waiting || this.waiting.length === 0) {
+			// If file required in tests is changed, webpack compilation is done silently for karma.
+			// Fix this by emulating test file change.
+			this.notifyKarmaAboutChanges(stats);
+		}
+
+		var complete = true;
+		if (stats.children && stats.children.length) {
+			complete = stats.children.every(function(stats) {
+				return stats.assets.length > 0;
+			});
+		}
+		if (stats.assets) {
+			complete = complete && stats.assets.length > 0;
+		}
+
+		if(this.waiting && complete) {
+			var w = this.waiting;
+			this.waiting = null;
+			w.forEach(function(cb) {
+				cb();
+			});
+		}
+	}.bind(this));
+	compiler.plugin("invalid", function() {
+		if(!this.waiting) this.waiting = [];
+	}.bind(this));
 
 	var server = this.server = new webpackDevServer(compiler, webpackServerOptions);
 	server.listen(port, hostname);

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function Plugin(/* config.port */karmaPort, /* config.hostname */hostname, /* co
 	var compiler = webpack(webpackOptions);
 	var applyPlugins = compiler.compilers || [compiler];
 	applyPlugins.forEach(function(compiler) {
-		compiler.plugin("compilation", function(compilation, params) {
+		compiler.plugin("this-compilation", function(compilation, params) {
 			compilation.dependencyFactories.set(SingleEntryDependency, params.normalModuleFactory);
 		});
 		compiler.plugin("make", this.make.bind(this));

--- a/mocha-env-loader.js
+++ b/mocha-env-loader.js
@@ -1,0 +1,23 @@
+var path = require("path");
+var SourceNode = require("source-map").SourceNode;
+
+module.exports = function(content) {
+	this.cacheable();
+
+	var callback = this.async();
+	var fileName = path.relative(this.options.context, this.resource);
+	var id = this.options.configName || ("Compiler " + this.options.output.path.replace(/\/_js\/(\d*).*/, "$1"));
+
+	var sourceNode = new SourceNode(1, 0, fileName, content);
+	sourceNode.setSourceContent(fileName, content);
+
+	var concatSrc = new SourceNode();
+	concatSrc.add([
+		"describe(" + JSON.stringify(id)  + ", function() {\n",
+		sourceNode,
+		"});"
+	]);
+
+	var result = concatSrc.toStringWithSourceMap();
+	callback(undefined, result.code, result.map.toString());
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"karma": ">=0.12 < 1"
 	},
 	"dependencies": {
-		"async": "~0.9.0"
+		"async": "~0.9.0",
+		"source-map": "^0.1.41"
 	},
 	"devDependencies": {
 		"karma-mocha": "~0.1.9",


### PR DESCRIPTION
All of the compiler setup and plugin operations were assuming a singular Compiler instance vs. MultiCompiler constructs. This changes the behavior to allow for iteration over multiple compilers where necessary.

Fixes #31