### PR TITLE
Utilize webpack-dev-middleware for hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ module.exports = function(config) {
 			// each file acts as entry point for the webpack configuration
 		],
 
-		frameworks: ['webpack'],
-
 		preprocessors: {
 			// add webpack as preprocessor
 			'test/*_test.js': ['webpack'],
@@ -38,16 +36,11 @@ module.exports = function(config) {
 			// webpack configuration
 		},
 
-		webpackServer: {
-			// webpack-dev-server configuration
+		webpackMiddleware: {
 			// webpack-dev-middleware configuration
 			// i. e.
 			noInfo: true
 		},
-
-		// the port used by the webpack-dev-server
-		// defaults to "config.port" + 1
-		webpackPort: 1234,
 
 		plugins: [
 			require("karma-webpack")
@@ -120,13 +113,9 @@ This is the full list of options you can specify in your Karma config.
 
 Webpack configuration.
 
-### webpackServer
+### webpackMiddleware
 
-Configuration for webpack-dev-server and webpack-dev-middleware.
-
-### webpackPort
-
-Port used by the webpack-dev-server. Defaults to "karmaConfig.port" + 1.
+Configuration for webpack-dev-middleware.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function createPreprocesor(/* config.basePath */basePath, webpackPlugin, fileLis
 				throw err;
 			}
 
-			done(err, content);
+			done(err, content && content.toString());
 		});
 	};
 }

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
 	"description": "Use webpack with karma",
 	"peerDependencies": {
 		"webpack": "^1.4.0",
-		"webpack-dev-server": "^1.0.0",
 		"karma": ">=0.12 < 1"
 	},
 	"dependencies": {
 		"async": "~0.9.0",
+		"loader-utils": "^0.2.5",
 		"source-map": "^0.1.41",
-		"loader-utils": "^0.2.5"
+		"webpack-dev-middleware": "^1.0.11"
 	},
 	"devDependencies": {
 		"karma-mocha": "~0.1.9",


### PR DESCRIPTION
The prior solution of pushing all content to the to the webpack server broke down for globs and watching. Karma really desires files and also prefers one to one mapping of said files and trying to fight that was not fruitful.

Instead opted to move all entry points back to the normal Karma serving routes and any auxiliary resources through the middleware.

This also removes much of the complexity and potential overhead relating to tracking individual file changes as Karma does not seem to do incremental testing and a filelist refresh will ensure that the rebuild occurs.

Fixes #1