### PR TITLE
Added lodash to clone reference options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var _ = require("lodash");
 var path = require("path");
 var async = require("async");
 var webpackDevMiddleware = require("webpack-dev-middleware");
@@ -14,9 +15,8 @@ function Plugin(
 			fileList,
 			customFileHandlers,
 			emitter) {
-	if(!webpackOptions) webpackOptions = {};
-
-	if(!webpackMiddlewareOptions) webpackMiddlewareOptions = webpackServerOptions || {};
+	webpackOptions = _.clone(webpackOptions) || {};
+	webpackMiddlewareOptions = _.clone(webpackMiddlewareOptions || webpackServerOptions) || {};
 
 	var applyOptions = Array.isArray(webpackOptions) ? webpackOptions : [webpackOptions];
 	var includeIndex = applyOptions.length > 1;

--- a/package.json
+++ b/package.json
@@ -1,34 +1,35 @@
 {
-	"name": "karma-webpack",
-	"version": "1.5.0",
-	"author": "Tobias Koppers @sokra",
-	"description": "Use webpack with karma",
-	"peerDependencies": {
-		"webpack": "^1.4.0",
-		"karma": ">=0.12 < 1"
-	},
-	"dependencies": {
-		"async": "~0.9.0",
-		"loader-utils": "^0.2.5",
-		"source-map": "^0.1.41",
-		"webpack-dev-middleware": "^1.0.11"
-	},
-	"devDependencies": {
-		"karma-mocha": "~0.1.9",
-		"karma-chrome-launcher": "~0.1.5",
-		"karma-spec-reporter": "~0.0.16",
-		"coffee-loader": "~0.7.2"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	],
-	"homepage": "http://github.com/webpack/karma-webpack",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/webpack/karma-webpack.git"
-	},
-	"main": "index.js"
+  "name": "karma-webpack",
+  "version": "1.5.0",
+  "author": "Tobias Koppers @sokra",
+  "description": "Use webpack with karma",
+  "peerDependencies": {
+    "webpack": "^1.4.0",
+    "karma": ">=0.12 < 1"
+  },
+  "dependencies": {
+    "async": "~0.9.0",
+    "loader-utils": "^0.2.5",
+    "lodash": "^3.8.0",
+    "source-map": "^0.1.41",
+    "webpack-dev-middleware": "^1.0.11"
+  },
+  "devDependencies": {
+    "karma-mocha": "~0.1.9",
+    "karma-chrome-launcher": "~0.1.5",
+    "karma-spec-reporter": "~0.0.16",
+    "coffee-loader": "~0.7.2"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "homepage": "http://github.com/webpack/karma-webpack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webpack/karma-webpack.git"
+  },
+  "main": "index.js"
 }


### PR DESCRIPTION
So yesterday I was pulling my hair out: _why_ the hell were my Karma config options changing when I ran `gulp-karma` **before** I then ran `gulp-webpack` with the same options object. I then dived into this code and saw that the object arguments being passed are being manipulated. Super sad times.

So what I've done is simply used lodash's `_.clone` so that this plugin's magic doesn't mess with my magic and we're all happy; I hope that's ok.

![](http://www.quickmeme.com/img/14/14c0f057abec6dabfc5be48cbbd0d904fef889a8781eee667984089207daf998.jpg)