### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "karma-spec-reporter": "~0.0.16",
     "coffee-loader": "~0.7.2"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "homepage": "http://github.com/webpack/karma-webpack",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license