### PR TITLE
fix: Drop karma as a peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Use webpack with karma",
   "peerDependencies": {
-    "webpack": "^1.4.0",
-    "karma": ">=0.12 < 1"
+    "webpack": "^1.4.0"
   },
   "dependencies": {
     "async": "~0.9.0",
@@ -15,6 +14,7 @@
     "webpack-dev-middleware": "^1.0.11"
   },
   "devDependencies": {
+    "karma": ">=0.12 < 1",
     "karma-mocha": "~0.1.9",
     "karma-chrome-launcher": "~0.1.5",
     "karma-spec-reporter": "~0.0.16",


### PR DESCRIPTION
We have decided to drop `karma` as a peer dependency, as there a lot of issues when trying to use release candidate versions. I'm now in the middle of making the needed PRs to do this, would be great to see this merged, as that means people can actually use versions like the current canary `0.13.0-rc.4` with the plugin.

For more discussion and reasoning see karma-runner/integration-tests#5.