### PR TITLE
Allow overriding webpack log options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Configuration for webpack-dev-middleware.
 
 ### webpackLogging
 
-Override the default webpack-middleware log ("normal" by default).  You can set this to one of the following:
+Configure the webpack stats log ("normal" by default).  You can set this to one of the following:
 
 * **String:** Convenience presets; one of `none`, `errors-only`, `minimal`, `normal`, `verbose`.  
 	> _Warning: `none` will completely silence any webpack output, including any possible errors._

--- a/README.md
+++ b/README.md
@@ -117,6 +117,37 @@ Webpack configuration.
 
 Configuration for webpack-dev-middleware.
 
+### webpackLogging
+
+Override the default webpack-middleware log.  You can set this to one of the following:
+
+* **String:** Convenience presets; one of `none`, `errors-only`, `minimal`, `normal`, `verbose`.  
+	> _Warning: `none` will completely silence any webpack output, including any possible errors._
+	
+	```
+	webpackLogging: 'normal'
+	```
+	
+* **Config object:** An object that will be passed on to `stats.toString()`.  See [here](https://github.com/webpack/webpack/blob/master/lib/Stats.js#L26-L40) for all possible options.
+	
+	```
+	webpackLogging: {
+		colors: true,
+		chunkModules: false
+	}
+	```
+
+* **Function:** Your own logging function
+	```
+	webpackLogging: function(stats, files) {
+		// your code
+		options = { colors: true }
+		console.log(stats.toString(options));
+	}
+	```
+* **Boolean:** `true` is alias of `normal`, `false` is alias of `none`
+* **Null:** Equivalent of not setting the `webpackLogging` key, uses the default webpack-middleware logging.
+
 ## License
 
 Copyright 2014-2015 Tobias Koppers

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Configuration for webpack-dev-middleware.
 
 ### webpackLogging
 
-Override the default webpack-middleware log.  You can set this to one of the following:
+Override the default webpack-middleware log ("normal" by default).  You can set this to one of the following:
 
 * **String:** Convenience presets; one of `none`, `errors-only`, `minimal`, `normal`, `verbose`.  
 	> _Warning: `none` will completely silence any webpack output, including any possible errors._
@@ -145,8 +145,8 @@ Override the default webpack-middleware log.  You can set this to one of the fol
 		console.log(stats.toString(options));
 	}
 	```
-* **Boolean:** `true` is alias of `normal`, `false` is alias of `none`
-* **Null:** Equivalent of not setting the `webpackLogging` key, uses the default webpack-middleware logging.
+* **Boolean:** `true` is alias of `normal`, `false` is alias of `none` (see above)
+* **Null:** Use webpack-middleware logging instead (not recommended).
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -72,43 +72,17 @@ function Plugin(
 		if(webpackLogging) {
 			//Disable webpack-middleware's default logging to use custom one
 			webpackMiddlewareOptions.quiet = true;
+			var webpackLoggingOptions = webpackLogging;
 
 			if(_.isFunction(webpackLogging)) {
 				webpackLogging(stats, this.files);
-			} else {
-				var webpackLoggingOptions = {};
-				if(webpackLogging === true) webpackLogging = 'normal';
-				else if(webpackLogging === false) webpackLogging = 'none';
-
-				if(_.isString(webpackLogging)) {
-					var wo = webpackLogging.toLowerCase();
-					if(wo === 'none') {
-						webpackLoggingOptions = null;
-					} else {
-						webpackLoggingOptions = {
-							//Available options: https://github.com/webpack/webpack/blob/master/lib/Stats.js#L26-L40
-							assets: wo === 'verbose',
-							version: wo === 'verbose',
-							timings: wo !== 'errors-only' && wo !== 'minimal',
-							hash: wo !== 'errors-only' && wo !== 'minimal',
-							chunks: wo !== 'errors-only',
-							chunkModules: wo === 'verbose',
-							errorDetails: wo !== 'errors-only' && wo !== 'minimal',
-						  reasons: wo === 'verbose',
-							colors: true
-						};
-					}
-				} else if(_.isPlainObject(webpackLogging)) {
-					webpackLoggingOptions = webpackLogging;
-				}
-				if(webpackLoggingOptions !== null) {
-					var chalk = require("chalk"),
-							stringStats = stats.toString(webpackLoggingOptions);
-					if(stringStats.trim().length > 0) {
-						console.log(chalk.cyan("Karma-Webpack bundle: ") + "\n", 
-						//"Files: ", chalk.bold(this.files.join(', ')), "\n",
-						stringStats, "\n");
-					}
+			} else if(webpackLoggingOptions) {
+				var chalk = require("chalk"),
+						stringStats = stats.toString(webpackLoggingOptions);
+				if(stringStats.trim().length > 0) {
+					console.log(chalk.cyan("Karma-Webpack bundle: ") + "\n", 
+					//"Files: ", chalk.bold(this.files.join(', ')), "\n",
+					stringStats, "\n");
 				}
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function Plugin(
 				noAssets = true;
 		});
 
+		webpackLogging = (typeof webpackLogging === "undefined" ? "normal" : webpackLogging);
 		if(webpackLogging) {
 			//Disable webpack-middleware's default logging to use custom one
 			webpackMiddlewareOptions.quiet = true;

--- a/index.js
+++ b/index.js
@@ -70,13 +70,14 @@ function Plugin(
 		});
 
 		webpackLogging = (typeof webpackLogging === "undefined" ? "normal" : webpackLogging);
-		if(webpackLogging) {
+		if(webpackLogging !== null) {
 			//Disable webpack-middleware's default logging to use custom one
 			webpackMiddlewareOptions.quiet = true;
 			
 			if(_.isFunction(webpackLogging)) {
 				webpackLogging(stats, this.files);
 			} else if(webpackLogging) {
+				if(webpackLogging === true) webpackLogging = "normal";
 				var chalk = require("chalk"),
 				    stringStats = stats.toString(webpackLogging);
 				if(stringStats.trim().length > 0) {

--- a/index.js
+++ b/index.js
@@ -73,13 +73,12 @@ function Plugin(
 		if(webpackLogging) {
 			//Disable webpack-middleware's default logging to use custom one
 			webpackMiddlewareOptions.quiet = true;
-			var webpackLoggingOptions = webpackLogging;
-
+			
 			if(_.isFunction(webpackLogging)) {
 				webpackLogging(stats, this.files);
-			} else if(webpackLoggingOptions) {
+			} else if(webpackLogging) {
 				var chalk = require("chalk"),
-						stringStats = stats.toString(webpackLoggingOptions);
+				    stringStats = stats.toString(webpackLogging);
 				if(stringStats.trim().length > 0) {
 					console.log(chalk.cyan("Karma-Webpack bundle: ") + "\n", 
 					//"Files: ", chalk.bold(this.files.join(', ')), "\n",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
+    "chalk": "^1.1.0",
     "loader-utils": "^0.2.5",
     "lodash": "^3.8.0",
     "source-map": "^0.1.41",


### PR DESCRIPTION
Sometimes the default webpack log makes it very hard to track bugs, and customizing it is not very easy.  This PR enables some handy presets (`none`, `errors-only`, `minimal`, `normal`, `verbose`) and opens the possibility to deeply customize everything for anyone that needs it.

See the new feature's [documentation here](https://github.com/MrFusion42/karma-webpack/blob/master/README.md#webpacklogging).

This is before:
<img width="1165" alt="karma-webpack-before" src="https://cloud.githubusercontent.com/assets/2915101/8492299/5efd51d8-210d-11e5-93b4-233c6d805f15.png">

And after (with `webpackLogging` set to `normal`):
<img width="1163" alt="karma-webpack-after" src="https://cloud.githubusercontent.com/assets/2915101/8492316/95b88c1a-210d-11e5-861b-c0d1928dc512.png">