### PR TITLE
Upgrade to use the new public karma api for refreshing files

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ function Plugin(
 			/* config.basePath */basePath,
 			/* config.files */files,
 			/* config.frameworks */frameworks,
-			fileList,
 			customFileHandlers,
 			emitter) {
 	webpackOptions = _.clone(webpackOptions) || {};
@@ -41,7 +40,7 @@ function Plugin(
 		webpackOptions.output.chunkFilename = "[id].chunk.js";
 	});
 
-	this.fileList = fileList;
+	this.emitter = emitter;
 	this.wrapMocha = frameworks.indexOf('mocha') >= 0 && includeIndex;
 	this.optionsCount = applyOptions.length;
 	this.files = [];
@@ -106,7 +105,7 @@ function Plugin(
 
 Plugin.prototype.notifyKarmaAboutChanges = function() {
 	// Force a rebuild
-	this.fileList.refresh();
+	this.emitter.refreshFiles();
 };
 
 Plugin.prototype.addFile = function(entry) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "webpack-dev-middleware": "^1.0.11"
   },
   "devDependencies": {
-    "karma": ">=0.12 < 1",
+    "karma": ">=0.13.2 < 1",
     "karma-mocha": "~0.1.9",
     "karma-chrome-launcher": "~0.1.5",
     "karma-spec-reporter": "~0.0.16",


### PR DESCRIPTION
I've just released `0.13.2` which adds a public api, that avoids having the breakage that was experienced with the upgrade to `0.13.0`

Closes #62, https://github.com/karma-runner/karma/issues/1497