### PR TITLE
Fix Issue Where refreshFiles is not defined on emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,9 @@ function Plugin(
 
 Plugin.prototype.notifyKarmaAboutChanges = function() {
 	// Force a rebuild
-	this.emitter.refreshFiles();
+	if (this.emitter.refreshFiles) {
+	    this.emitter.refreshFiles();
+	}
 };
 
 Plugin.prototype.addFile = function(entry) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-webpack",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "Tobias Koppers @sokra",
   "description": "Use webpack with karma",
   "peerDependencies": {


### PR DESCRIPTION
This PR resolves the following issue that is occurring on a build with the latest `karma` and `karma-webpack`
```
WARN [preprocess]: Can not load "webpack"!
  TypeError: Object [object Object] has no method 'refreshFiles'
    at Plugin.notifyKarmaAboutChanges (/Repositories/UI/services-ui/node_modules/karma-webpack/index.js:109:15)
    at Plugin.<anonymous> (/Repositories/UI/services-ui/node_modules/karma-webpack/index.js:72:9)
    at Tapable.applyPlugins (/Repositories/UI/services-ui/node_modules/webpack/node_modules/tapable/lib/Tapable.js:26:37)
    at Watching._done (/Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:78:17)
    at Watching.<anonymous> (/Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:61:18)
    at Tapable.emitRecords (/Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:281:37)
    at Watching.<anonymous> (/Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:58:19)
    at /Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:274:11
    at Tapable.applyPluginsAsync (/Repositories/UI/services-ui/node_modules/webpack/node_modules/tapable/lib/Tapable.js:60:69)
    at Tapable.afterEmit (/Repositories/UI/services-ui/node_modules/webpack/lib/Compiler.js:271:8)
```