### PR TITLE
remove plugins property

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,7 @@ module.exports = function(config) {
 			// webpack-dev-middleware configuration
 			// i. e.
 			noInfo: true
-		},
-
-		plugins: [
-			require("karma-webpack")
-		]
-
+		}
 	});
 };
 ```


### PR DESCRIPTION
karma loads all plugins with 'karma-' automatically, including 'plugins' property in config leads to cryptic error messages when attempting to run karma.