### PR TITLE
Do not let karma watch files on the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ module.exports = function(config) {
     // ... normal karma configuration
     files: [
       // all files ending in "_test"
-      [{pattern: 'test/*_test.js', watched: false, included: true, served: true}],
-      [{pattern: 'test/**/*_test.js', watched: false, included: true, served: true}],
+      {pattern: 'test/*_test.js', watched: false},
+      {pattern: 'test/**/*_test.js', watched: false},
       // each file acts as entry point for the webpack configuration
     ],
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ module.exports = function(config) {
     // ... normal karma configuration
     files: [
       // all files ending in "_test"
-      'test/*_test.js',
-      'test/**/*_test.js'
+      [{pattern: 'test/*_test.js', watched: false, included: true, served: true}],
+      [{pattern: 'test/**/*_test.js', watched: false, included: true, served: true}],
       // each file acts as entry point for the webpack configuration
     ],
 
@@ -227,4 +227,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module.exports = function(config) {
     files: [
       // all files ending in "_test"
       {pattern: 'test/*_test.js', watched: false},
-      {pattern: 'test/**/*_test.js', watched: false},
+      {pattern: 'test/**/*_test.js', watched: false}
       // each file acts as entry point for the webpack configuration
     ],
 


### PR DESCRIPTION
This prevents specs from running twice every time a file changes, because karma-webpack already triggers a rerun when recompiled.

Thanks to this comment: https://github.com/webpack/karma-webpack/issues/44#issuecomment-133619802