### PR TITLE
Do not silently swallow ENOENT errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function Plugin(
 			/* config.files */files,
 			/* config.frameworks */frameworks,
 			customFileHandlers,
-                        emitter,
-                        logger) {
+			emitter,
+			logger) {
 	webpackOptions = _.clone(webpackOptions) || {};
 	webpackMiddlewareOptions = _.clone(webpackMiddlewareOptions || webpackServerOptions) || {};
 
@@ -41,7 +41,7 @@ function Plugin(
 		webpackOptions.output.chunkFilename = "[id].chunk.js";
 	});
 
-        this.log = logger.create('plugin.webpack');
+	this.log = logger.create('plugin.webpack');
 	this.emitter = emitter;
 	this.wrapMocha = frameworks.indexOf('mocha') >= 0 && includeIndex;
 	this.optionsCount = applyOptions.length;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function Plugin(
 			/* config.files */files,
 			/* config.frameworks */frameworks,
 			customFileHandlers,
-			emitter) {
+                        emitter,
+                        logger) {
 	webpackOptions = _.clone(webpackOptions) || {};
 	webpackMiddlewareOptions = _.clone(webpackMiddlewareOptions || webpackServerOptions) || {};
 
@@ -40,6 +41,7 @@ function Plugin(
 		webpackOptions.output.chunkFilename = "[id].chunk.js";
 	});
 
+        this.log = logger.create('plugin.webpack');
 	this.emitter = emitter;
 	this.wrapMocha = frameworks.indexOf('mocha') >= 0 && includeIndex;
 	this.optionsCount = applyOptions.length;
@@ -123,8 +125,11 @@ Plugin.prototype.make = function(compilation, callback) {
 
 		var dep = new SingleEntryDependency(entry);
 		compilation.addEntry("", dep, path.relative(this.basePath, file).replace(/\\/g, "/"), function() {
+		        if(dep.module && dep.module.error && dep.module.error.error && dep.module.error.error.stack) {
+                                this.log.warn(dep.module.error.error.stack);
+                        }
 			// If the module fails because of an File not found error, remove the test file
-			if(dep.module && dep.module.error && dep.module.error.error && dep.module.error.error.code === "ENOENT") {
+		        if(dep.module && dep.module.error && dep.module.error.error && dep.module.error.error.code === "ENOENT") {
 				this.files = this.files.filter(function(f) {
 					return file !== f;
 				});


### PR DESCRIPTION
I recently ran in to an issue using karma, karma-webpack, and typescript (via the ts-loader module). My editor generated a `.#*` file, which caused the typescript compiler to throw an error.  The precise error was an ENOENT error, which karma-webpack silently swallowed. I think this is because the original author assumed that this would generally be caused by a transient file during transpilation operations, and that it would be safe to simply ignore and proceed. 

In my case, however, the end user experience was:
1. Run `karma start`
2. See some webpack output (no errors or warnings)
3. Process exits with exit code 0.
4. Me: what the heck?

With this patch, the user will at least see a warning message that will clue them in to what is going on.
