### PR TITLE
silence webpack output using stats: 'errors-only'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module.exports = function(config) {
 		webpackMiddleware: {
 			// webpack-dev-middleware configuration
 			// i. e.
-			noInfo: true
+			stats: 'errors-only'
 		},
 
 		plugins: [


### PR DESCRIPTION
see https://github.com/webpack/webpack/issues/1191 - noInfo: true did not work