### PR TITLE
Add webpack 2.0 beta to peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Use webpack with karma",
   "peerDependencies": {
-    "webpack": "^1.4.0"
+    "webpack": "^1.4.0 || ^2.1.0-beta"
   },
   "dependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
This loader works fine with beta versions of webpack 2.0 but it`s impossible to try it easily, because of unmet peer dependencies.