### PR TITLE
Adding webpack blocker to stop karma from running tests until build is finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Without the `webpackBlocker` middleware karma will serve files from before
 the code change. With the `webpackBlocker` middleware the loader will not serve
 the files until the code has finished recompiling.
 
+Note that the `beforeMiddleware` option is only supported in karma with version >1.0.
+
 ## License
 
 Copyright 2014-2015 Tobias Koppers

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ module.exports = function(config) {
 			// webpack configuration
 		},
 
+		// optional middleware that blocks tests from running until code
+		// recompiles
+		beforeMiddleware: [
+			'webpackBlocker'
+		],
+
 		webpackMiddleware: {
 			// webpack-dev-middleware configuration
 			// i. e.
@@ -115,6 +121,21 @@ Webpack configuration.
 ### webpackMiddleware
 
 Configuration for webpack-dev-middleware.
+
+### beforeMiddleware
+
+`beforeMiddleware` is a webpack option that allows injecting middleware before
+karama's own middleware are run. This loader provides a `webpackBlocker`
+middleware that will block tests from running until code recompiles. That is,
+given this scenario:
+
+1. Have a browser open on the karma debug page (http://localhost:9876/debug.html)
+2. Make a code change
+3. Refresh
+
+Without the `webpackBlocker` middleware karma will serve files from before
+the code change. With the `webpackBlocker` middleware the loader will not serve
+the files until the code has finished recompiling.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var webpackDevMiddleware = require("webpack-dev-middleware");
 var webpack = require("webpack");
 var SingleEntryDependency = require("webpack/lib/dependencies/SingleEntryDependency");
 
+var blocked = []
+var isBlocked = false
+
 function Plugin(
 	webpackOptions, /* config.webpack */
 	webpackServerOptions, /* config.webpackServer */
@@ -61,6 +64,10 @@ function Plugin(
 		compiler.plugin("make", this.make.bind(this));
 	}, this);
 
+	compiler.plugin("compile", function() {
+		isBlocked = true
+	})
+
 	compiler.plugin("done", function(stats) {
 		var applyStats = Array.isArray(stats.stats) ? stats.stats : [stats];
 		var assets = [];
@@ -84,6 +91,12 @@ function Plugin(
 				cb();
 			});
 		}
+
+		isBlocked = false
+		for (var i = 0; i < blocked.length; i++) {
+			blocked[i]();
+		}
+		blocked = []
 	}.bind(this));
 	compiler.plugin("invalid", function() {
 		if(!this.waiting) this.waiting = [];
@@ -188,7 +201,18 @@ function createPreprocesor( /* config.basePath */ basePath, webpackPlugin) {
 	};
 }
 
+function createWebpackBlocker() {
+	return function (request, response, next) {
+		if (isBlocked) {
+			blocked.push(next)
+		} else {
+			next()
+		}
+	}
+}
+
 module.exports = {
 	"webpackPlugin": ["type", Plugin],
-	"preprocessor:webpack": ["factory", createPreprocesor]
+	"preprocessor:webpack": ["factory", createPreprocesor],
+	"middleware:webpackBlocker": ["factory", createWebpackBlocker]
 };

--- a/index.js
+++ b/index.js
@@ -64,8 +64,14 @@ function Plugin(
 		compiler.plugin("make", this.make.bind(this));
 	}, this);
 
-	compiler.plugin("compile", function() {
-		isBlocked = true
+	["invalid", "watch-run", "run"].forEach(function(name) {
+		compiler.plugin(name, function(_, callback) {
+			isBlocked = true;
+
+			if (callback) {
+				callback();
+			}
+		})
 	})
 
 	compiler.plugin("done", function(stats) {


### PR DESCRIPTION
When you make a code change and then refresh karma, sometimes karma will serve the old test files (because webpack is recompiling). This behavior can become annoying and waste time.

This change adds an optional middleware that will block karma from serving the test files until the build is complete.

Note that the middleware needs to be injected before karma's middleware, which is in this PR: https://github.com/karma-runner/karma/pull/2143

We should hold off on merging until the karma PR above is merged.