### PR TITLE
Apply linting rules with beautify-rewrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,18 @@ var blocked = []
 var isBlocked = false
 
 function Plugin(
-	/* config.webpack */ webpackOptions,
-	/* config.webpackServer */ webpackServerOptions,
-	/* config.webpackMiddleware */ webpackMiddlewareOptions,
-	/* config.basePath */ basePath,
-	/* config.files */ files,
-	/* config.frameworks */ frameworks,
+	/* config.webpack */
+	webpackOptions,
+	/* config.webpackServer */
+	webpackServerOptions,
+	/* config.webpackMiddleware */
+	webpackMiddlewareOptions,
+	/* config.basePath */
+	basePath,
+	/* config.files */
+	files,
+	/* config.frameworks */
+	frameworks,
 	customFileHandlers,
 	emitter) {
 	webpackOptions = _.clone(webpackOptions) || {};
@@ -68,7 +74,7 @@ function Plugin(
 		compiler.plugin(name, function(_, callback) {
 			isBlocked = true;
 
-			if (callback) {
+			if(callback) {
 				callback();
 			}
 		})
@@ -99,7 +105,7 @@ function Plugin(
 		}
 
 		isBlocked = false
-		for (var i = 0; i < blocked.length; i++) {
+		for(var i = 0; i < blocked.length; i++) {
 			blocked[i]();
 		}
 		blocked = []
@@ -209,7 +215,7 @@ function createPreprocesor( /* config.basePath */ basePath, webpackPlugin) {
 
 function createWebpackBlocker() {
 	return function(request, response, next) {
-		if (isBlocked) {
+		if(isBlocked) {
 			blocked.push(next)
 		} else {
 			next()


### PR DESCRIPTION
This PR fixes linting errors.

@d3viant0ne pointed out at the bottom of #147 that the PR had introduced linting errors into the repo. I missed those last night, and wanted to fix my error(s).

This commit created by running:

    $ ./node_modules/.bin/beautify-rewrite *.js

The results can be verified with:

    $ npm run pretest

`beautify-rewrite` maintains the order of the meta-data comments vis-a-vis parameters, and a [new branch on the MVE](https://github.com/jambonsw/webpack2-karma-logging-error-mve/tree/karma_webpack_issue_146_with_linting) seems to work fine, but I'd love a double-check.

Thanks again to @goldhand, @MikaAK and @d3viant0ne for the rapid review and quick fix of these issues.