### PR TITLE
Fix 151 - wrap callback in exception handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,11 @@ function Plugin(
 			isBlocked = true;
 
 			if (callback) {
-				callback();
+				try {
+					callback();
+				} catch (err) {
+					// do nothing
+				}
 			}
 		})
 	})


### PR DESCRIPTION
As noted in #151, there are occasions when `callback` is actually a Number, and not a function.

This PR wraps the attempt to call the `callback`, and simply keeps chugging along in the event that something caused an issue.

I am not super proud of this solution: there is probably a more selectively robust manner of handling this, but as I'm unclear on exactly what's going on, I am unable to provide more than a stop-gap measure.