### PR TITLE
chore(deps): Use patch version of dev-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "loader-utils": "^0.2.5",
     "lodash": "^3.8.0",
     "source-map": "^0.1.41",
-    "webpack-dev-middleware": "^1.0.11"
+    "webpack-dev-middleware": "~1.0.11"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
As discussed in #56 dev-middleware introduced a breaking change on a minor version bump as we currently target minor version not patch.


**What is the new behavior?**
Temporarily sets the `webpack-dev-middleware` version to patch from minor for updates until proper unit tests are in place and the issue can be addressed with the middleware team.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding: #56 


**Other information**:
Resolves #56

