### PR TITLE
Add .js suffix to output files so that source maps are generated for …

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -46,7 +46,7 @@ function Plugin(
     // https://github.com/webpack/webpack/issues/645
     webpackOptions.output.path = '/_karma_webpack_/' + indexPath
     webpackOptions.output.publicPath = '/_karma_webpack_/' + publicPath
-    webpackOptions.output.filename = '[name]'
+    webpackOptions.output.filename = '[name].js'
     if (includeIndex) {
       webpackOptions.output.jsonpFunction = 'webpackJsonp' + index
     }
@@ -184,7 +184,7 @@ Plugin.prototype.readFile = function(file, callback) {
   function doRead() {
     if (optionsCount > 1) {
       async.times(optionsCount, function(idx, callback) {
-        middleware.fileSystem.readFile('/_karma_webpack_/' + idx + '/' + file.replace(/\\/g, '/'), callback)
+        middleware.fileSystem.readFile('/_karma_webpack_/' + idx + '/' + file.replace(/\\/g, '/') + '.js', callback)
       }, function(err, contents) {
         if (err) {
           return callback(err)
@@ -200,7 +200,7 @@ Plugin.prototype.readFile = function(file, callback) {
         callback(null, Buffer.concat(contents))
       })
     } else {
-      middleware.fileSystem.readFile('/_karma_webpack_/' + file.replace(/\\/g, '/'), callback)
+      middleware.fileSystem.readFile('/_karma_webpack_/' + file.replace(/\\/g, '/') + '.js', callback)
     }
   }
   if (!this.waiting) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

[Source maps are not generated](https://github.com/webpack/karma-webpack/issues/121) because [they expect a suffix of .js](https://github.com/webpack/webpack/blob/5b5775f9e2fc73fea46629f2d6a3ed7a1f8424d3/lib/SourceMapDevToolPlugin.js#L35)

**What is the new behavior?**

Add the .js suffix to the output files so that source maps are generated.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
