### PR TITLE
chore(package): allow Webpack 2.2.0 rc as peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/webpack/karma-webpack.git"
   },
   "peerDependencies": {
-    "webpack": "^1.1.0 || ^2 || ^2.1.0-beta"
+    "webpack": "^1.1.0 || ^2 || ^2.1.0-beta || ^2.2.0-rc"
   },
   "dependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
Resolves #186

//cc @MikaAK - This will need to be published for those wanting to use the Webpack Release Cnadidate